### PR TITLE
Fix: scroll view to the chosen region

### DIFF
--- a/easy_motion.py
+++ b/easy_motion.py
@@ -225,3 +225,4 @@ class JumpToWinningSelection(sublime_plugin.TextCommand):
         sel = self.view.sel()
         sel.clear()
         sel.add(winning_region)
+        self.view.show(winning_region)


### PR DESCRIPTION
The problem is that if cursor is outside of the visible area and you want to jump to a region inside visible area, it places cursor on that region, but view is scrolled to the place, where it was before. 

I've just added `self.view.show(winning_region` to scroll to the chosen region.
