### PR TITLE
Fix: init winning_selection before the first jump

### DIFF
--- a/easy_motion.py
+++ b/easy_motion.py
@@ -119,6 +119,7 @@ class EasyMotionCommand(sublime_plugin.WindowCommand):
     jump_group_iterator = None
     current_jump_group = None
     select_text = False
+    winning_selection = None
 
     def run(self, character=None, select_text=False):
         sublime.status_message("SublimeJump to " + character)


### PR DESCRIPTION
When I open new file, every time I do `cmd+;` and then `escape` to cancel (i.e. don't jump anywhere), I have this message in sublime console:

```
Traceback (most recent call last):
  File "./easy_motion.py", line 202, in finish_easy_motion
  File "./easy_motion.py", line 218, in jump_to_winning_selection
AttributeError: 'EasyMotionCommand' object has no attribute 'winning_selection'
```

Initialized `winning_selection` with `None`.
