### PR TITLE
Fixed issue #28; EasySelect broken before EasyMove

### DIFF
--- a/easy_motion.py
+++ b/easy_motion.py
@@ -220,8 +220,8 @@ class JumpTo(sublime_plugin.WindowCommand):
     def run(self, character=None):
         global COMMAND_MODE_WAS
 
-        self.winning_selection = self.winning_selection_from(character)
         self.active_view = self.window.active_view()
+        self.winning_selection = self.winning_selection_from(character)
         self.finish_easy_motion()
         self.active_view.settings().set('easy_motion_mode', False)
         if (COMMAND_MODE_WAS):


### PR DESCRIPTION
The JumpTo command was setting self.active_view after winning_selection_from; winning_selection_from uses self.active_view when SELECT_TEXT is set. Running JumpTo normally would result in this being set so subsequent calls would work. Just reversing the two lines in easy_motion.py (:223, :224) fixes the issue.

Thanks for the great plugin!
