### PR TITLE
renaming class and command JumpTo to EasymotionJumpTo

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1,23 +1,23 @@
 [
     /* haven't figured out why yet, but for some reason you need to hit ctrl+c or escape twice to get it to deactivate jump targets */
-    { 
-        "keys": ["ctrl+c"], 
+    {
+        "keys": ["ctrl+c"],
         "command": "deactivate_jump_targets", "context": [{"key": "setting.easy_motion_mode"}]
     },
-    { 
-        "keys": ["escape"], 
+    {
+        "keys": ["escape"],
         "command": "deactivate_jump_targets", "context": [{"key": "setting.easy_motion_mode"}]
     },
-    { 
-        "keys": ["<character>"], 
-        "command": "jump_to", "context": [{"key": "setting.easy_motion_mode"}]
+    {
+        "keys": ["<character>"],
+        "command": "easymotion_jump_to", "context": [{"key": "setting.easy_motion_mode"}]
     },
-    { 
-        "keys": ["enter"], 
+    {
+        "keys": ["enter"],
         "command": "show_jump_group", "context": [{"key": "setting.easy_motion_mode"}]
     },
-    { 
-        "keys": ["shift+enter"], 
-        "command": "show_jump_group", "context": [{"key": "setting.easy_motion_mode"}], "args": {"next": false} 
+    {
+        "keys": ["shift+enter"],
+        "command": "show_jump_group", "context": [{"key": "setting.easy_motion_mode"}], "args": {"next": false}
     }
 ]

--- a/easy_motion.py
+++ b/easy_motion.py
@@ -229,7 +229,7 @@ class UndoLastJumpTargets(sublime_plugin.WindowCommand):
         self.window.run_command("undo")
 
 
-class JumpTo(sublime_plugin.WindowCommand):
+class EasymotionJumpTo(sublime_plugin.WindowCommand):
     def run(self, character=None):
         global COMMAND_MODE_WAS
 


### PR DESCRIPTION
which resolves the conflict with the JumpTo plugin (https://github.com/tednaleid/sublime-EasyMotion/issues/41)

I haven't tested with ST2 though. I assume because the JumpTo plugin has a file jump_to.py Sublime tries to call this plugin with the named parameter 'character' which the JumpTo plugin doesn't understand
